### PR TITLE
added pre-build 'meteor npm install' step

### DIFF
--- a/base/scripts/lib/build_app.sh
+++ b/base/scripts/lib/build_app.sh
@@ -8,6 +8,8 @@ BUNDLE_DIR=/tmp/bundle-dir
 cp -R /app $COPIED_APP_PATH
 cd $COPIED_APP_PATH
 
+meteor npm install
+
 meteor build --directory $BUNDLE_DIR --server=http://localhost:3000
 
 cd $BUNDLE_DIR/bundle/programs/server/


### PR DESCRIPTION
#7 This is needed so that npm dependencies are available when building the application
